### PR TITLE
Kukumo Maven Plugin: correcciones y tests

### DIFF
--- a/kukumo-bom/pom.xml
+++ b/kukumo-bom/pom.xml
@@ -38,7 +38,7 @@
         <maven-fetcher.version>1.5.0</maven-fetcher.version>
         <log4j.version>2.19.0</log4j.version>
         <junit.version>4.13.2</junit.version>
-        <assertj-core.version>3.14.0</assertj-core.version>
+        <assertj-core.version>3.16.1</assertj-core.version>
         <jackson.version>2.13.2</jackson.version>
         <jackson-databind.version>2.13.2.2</jackson-databind.version>
         <snakeyaml.version>1.31</snakeyaml.version>
@@ -52,11 +52,8 @@
         <commons-io.version>2.11.0</commons-io.version>
         <commons-logging.version>1.2</commons-logging.version>
         <commons-configuration2.version>2.7</commons-configuration2.version>
-        <maven-plugin-api.version>3.8.1</maven-plugin-api.version>
+        <maven.version>3.8.1</maven.version>
         <maven-plugin-annotations.version>3.4</maven-plugin-annotations.version>
-        <maven-artifact.version>3.8.1</maven-artifact.version>
-        <maven-model.version>3.8.1</maven-model.version>
-        <maven-plugin-plugin.version>3.6.0</maven-plugin-plugin.version>
         <aether.version>1.0.2.v20150114</aether.version>
         <guice.version>4.2.2</guice.version>
         <guava.version>28.1-jre</guava.version>
@@ -79,7 +76,6 @@
         <javax-annotation-api.version>1.3.2</javax-annotation-api.version>
         <immutable-config.version>1.1.0</immutable-config.version>
         <maven-resolver.version>1.7.2</maven-resolver.version>
-        <maven-resolver-provider.version>3.8.1</maven-resolver-provider.version>
         <httpcore.version>4.4.14</httpcore.version>
         <httpclient.version>4.5.13</httpclient.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
@@ -264,7 +260,8 @@
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-plugin-api</artifactId>
-                <version>${maven-plugin-api.version}</version>
+                <version>${maven.version}</version>
+                <scope>provided</scope>
                 <exclusions>
                     <exclusion>
                         <groupId>org.codehaus.plexus</groupId>
@@ -279,6 +276,12 @@
                         <artifactId>plexus-component-annotations</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-core</artifactId>
+                <version>${maven.version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.plexus</groupId>
@@ -309,7 +312,8 @@
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-artifact</artifactId>
-                <version>${maven-artifact.version}</version>
+                <version>${maven.version}</version>
+                <scope>provided</scope>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.commons</groupId>
@@ -510,7 +514,8 @@
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-model</artifactId>
-                <version>${maven-model.version}</version>
+                <version>${maven.version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven.resolver</groupId>
@@ -535,13 +540,19 @@
             <dependency>
                 <groupId>org.apache.maven</groupId>
                 <artifactId>maven-resolver-provider</artifactId>
-                <version>${maven-resolver-provider.version}</version>
+                <version>${maven.version}</version>
+                <scope>provided</scope>
                 <exclusions>
                     <exclusion>
                         <groupId>org.apache.maven.resolver</groupId>
                         <artifactId>maven-resolver-api</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.maven</groupId>
+                <artifactId>maven-compat</artifactId>
+                <version>${maven.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>

--- a/kukumo-examples/spring-verify-example/pom.xml
+++ b/kukumo-examples/spring-verify-example/pom.xml
@@ -5,7 +5,7 @@
   ~ file, You can obtain one at https://mozilla.org/MPL/2.0/.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -26,10 +26,13 @@
 
     <properties>
         <java.version>1.8</java.version>
-        <kukumoLog>info</kukumoLog>
+        <kukumoLog>debug</kukumoLog>
         <maven.site.version>3.7.1</maven.site.version>
         <maven.ant.version>1.8</maven.ant.version>
         <spring-boot.version>2.0.5.RELEASE</spring-boot.version>
+
+        <jacoco.kukumo.execution.data.file>${project.build.directory}/coverage-reports/jacoco-kukumo.exec
+        </jacoco.kukumo.execution.data.file>
     </properties>
 
 
@@ -87,6 +90,13 @@
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <version>${jacoco.version}</version>
+            <classifier>runtime</classifier>
+        </dependency>
     </dependencies>
 
 
@@ -94,18 +104,24 @@
         <profile>
             <id>verify-profile</id>
             <activation>
-                <property><name>!skipExampleTests</name></property>
+                <property>
+                    <name>!skipExampleTests</name>
+                </property>
             </activation>
             <build>
                 <plugins>
+
 
                     <!-- Start Spring Boot application prior to integration tests and stop it afterwards -->
                     <plugin>
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-maven-plugin</artifactId>
                         <configuration>
-                            <wait>500</wait>
-                            <maxAttempts>30</maxAttempts>
+                            <jvmArguments>
+                                -Djacoco-agent.destfile=${jacoco.kukumo.execution.data.file}
+                                -Dspring.application.admin.enabled=true
+                                -Dspring.devtools.add-properties=false
+                            </jvmArguments>
                         </configuration>
                         <executions>
                             <execution>
@@ -139,22 +155,17 @@
                             </execution>
                         </executions>
                         <configuration>
+                            <configurationFiles>src/test/resources/kukumo.yaml</configurationFiles>
                             <!-- Enable/disable tests execution (enabled by default) -->
                             <skipTests>${skipExampleTests}</skipTests>
                             <!-- Set log level for the plugin (info by default) -->
                             <logLevel>${kukumoLog}</logLevel>
                             <!-- Kukumo configuration -->
                             <properties>
-                                <resourceTypes>gherkin</resourceTypes>
                                 <resourcePath>${project.basedir}/src/test/resources</resourcePath>
                                 <outputFilePath>target/kukumo/kukumo.json</outputFilePath>
                                 <logs.showStepSource>false</logs.showStepSource>
-                                <rest.baseURL>http://localhost:9191</rest.baseURL>
                                 <htmlReport.output>target/kukumo/kukumo.html</htmlReport.output>
-                                <database.connection.driver>org.h2.Driver</database.connection.driver>
-                                <database.connection.url>jdbc:h2:tcp://localhost:9092/~/test</database.connection.url>
-                                <database.connection.username>sa</database.connection.username>
-                                <database.connection.password></database.connection.password>
                             </properties>
                         </configuration>
                         <dependencies>
@@ -248,6 +259,49 @@
                 </configuration>
             </plugin>
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <skipTests>${skipExampleTests}</skipTests>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <configuration>
+                    <excludes>
+                        <exclude>**/App*</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>pre-integration-test</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>instrument</goal>
+                            <goal>prepare-agent-integration</goal>
+                        </goals>
+                        <configuration>
+                            <destFile>${jacoco.kukumo.execution.data.file}</destFile>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>integration-test</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>restore-instrumented-classes</goal>
+                            <goal>report</goal>
+                        </goals>
+                        <configuration>
+                            <dataFile>${jacoco.kukumo.execution.data.file}</dataFile>
+                            <outputDirectory>${project.build.directory}/jacoco-kukumo</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
             <!-- maven site -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -280,8 +334,5 @@
             <url>${project.baseUri}</url>
         </site>
     </distributionManagement>
-
-
-
 
 </project>

--- a/kukumo-examples/spring-verify-example/pom.xml
+++ b/kukumo-examples/spring-verify-example/pom.xml
@@ -155,7 +155,7 @@
                             </execution>
                         </executions>
                         <configuration>
-                            <configurationFiles>src/test/resources/kukumo.yaml</configurationFiles>
+                            <configurationFiles>${project.basedir}/src/test/resources/kukumo.yaml</configurationFiles>
                             <!-- Enable/disable tests execution (enabled by default) -->
                             <skipTests>${skipExampleTests}</skipTests>
                             <!-- Set log level for the plugin (info by default) -->

--- a/kukumo-examples/spring-verify-example/src/main/java/iti/kukumo/examples/spring/app/App.java
+++ b/kukumo-examples/spring-verify-example/src/main/java/iti/kukumo/examples/spring/app/App.java
@@ -10,21 +10,33 @@
 package iti.kukumo.examples.spring.app;
 
 
-import java.sql.SQLException;
-
+import org.h2.tools.DeleteDbFiles;
 import org.h2.tools.Server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.context.event.ContextClosedEvent;
+
+import javax.annotation.PreDestroy;
+import java.sql.SQLException;
 
 
 @SpringBootApplication
 public class App {
 
+    private static Server server;
+
     public static void main(String[] args) throws SQLException {
-        Server server = Server.createTcpServer("-tcpPort", "9092").start();
-        ConfigurableApplicationContext context = SpringApplication.run(App.class, args);
+        server = Server.createTcpServer("-tcpPort", "9092").start();
+        SpringApplication.run(App.class, args);
     }
 
+    @PreDestroy
+    public void shutdown() {
+        new Thread(() -> {
+            try {
+                Thread.sleep(100);
+            } catch (InterruptedException ignored) { }
+            server.stop();
+            DeleteDbFiles.execute("~", "test", false);
+        }).start();
+    }
 }

--- a/kukumo-examples/spring-verify-example/src/main/resources/application.yaml
+++ b/kukumo-examples/spring-verify-example/src/main/resources/application.yaml
@@ -7,9 +7,10 @@ spring:
     username: sa
     password:
     data: classpath:initial-data.sql
-    hibernate:
-        ddl-auto: create
-        
+#  jpa:
+#    hibernate:
+#      ddl-auto: create
+
 server:
   port: 9191
 

--- a/kukumo-examples/spring-verify-example/src/test/resources/UserService.feature
+++ b/kukumo-examples/spring-verify-example/src/test/resources/UserService.feature
@@ -17,14 +17,15 @@ Feature: User service operations
       """
 
    # Un-comment this scenario to test failing cases
-   #Scenario: An existing user is requested (will fail)
-   #   Given a user identified by '4'
-   #   And the following data inserted in the database table USER:
-   #     | ID | FIRST_NAME | LAST_NAME      |
-   #     | 4  | Arnorld    | Chuarcheneguer |
-   #   When the user is requested
-   #   Then the response HTTP code is 200
-   #   And the response contains:
-   #   """
-   #   { "lastName": "Schwarzenegger" }
-   #   """
+  @Ignore
+   Scenario: An existing user is requested (will fail)
+      Given a user identified by '4'
+      And the following data inserted into the database table USER:
+        | ID | FIRST_NAME | LAST_NAME      |
+        | 4  | Arnorld    | Chuarcheneguer |
+      When the user is requested
+      Then the response HTTP code is 200
+      And the response contains:
+      """
+      { "lastName": "Schwarzenegger" }
+      """

--- a/kukumo-examples/spring-verify-example/src/test/resources/kukumo.yaml
+++ b/kukumo-examples/spring-verify-example/src/test/resources/kukumo.yaml
@@ -1,0 +1,17 @@
+kukumo:
+  resourceTypes:
+    - gherkin
+  launcher:
+    modules:
+      - net.sf.jt400:jt400-jdk8:10.4
+  tagFilter: not Ignore
+
+  rest:
+    httpCodeThreshold: 999
+    baseURL: http://localhost:9191
+
+  database:
+    connection:
+      url: jdbc:h2:tcp://localhost:9092/~/test
+      username: sa
+      driver: org.h2.Driver

--- a/kukumo/kukumo-maven-plugin/CHANGELOG.md
+++ b/kukumo/kukumo-maven-plugin/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog][1],
 and this project adheres to [Semantic Versioning][2].
 
+## [1.4.1] 2022-10-25
+### Added
+- Configuration field `testFailureIgnore`
+- Tests
+
+### Fixed
+- The pipeline was broken when kukumo tests failed
 
 ## [1.2.1] 2021-10-22
 ### Modified

--- a/kukumo/kukumo-maven-plugin/pom.xml
+++ b/kukumo/kukumo-maven-plugin/pom.xml
@@ -28,6 +28,9 @@
     <description>Maven Plugin for Kukumo</description>
     <inceptionYear>2019</inceptionYear>
 
+    <properties>
+        <maven-plugin-testing-harness.version>3.3.0</maven-plugin-testing-harness.version>
+    </properties>
 
     <dependencyManagement>
         <dependencies>
@@ -41,8 +44,6 @@
         </dependencies>
     </dependencyManagement>
 
-
-
     <dependencies>
         <dependency>
             <groupId>es.iti.kukumo</groupId>
@@ -53,6 +54,10 @@
             <artifactId>maven-plugin-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
@@ -60,6 +65,29 @@
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.maven.resolver</groupId>
+            <artifactId>maven-resolver-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.maven.plugin-testing</groupId>
+            <artifactId>maven-plugin-testing-harness</artifactId>
+            <version>${maven-plugin-testing-harness.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-compat</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>4.8.1</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
 
@@ -67,7 +95,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-plugin-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>3.6.4</version>
             </plugin>
         </plugins>
     </build>

--- a/kukumo/kukumo-maven-plugin/src/main/java/iti/kukumo/maven/KukumoConfigurable.java
+++ b/kukumo/kukumo-maven-plugin/src/main/java/iti/kukumo/maven/KukumoConfigurable.java
@@ -10,32 +10,30 @@
 package iti.kukumo.maven;
 
 
+import imconfig.Configuration;
+import imconfig.ConfigurationException;
+import iti.kukumo.core.Kukumo;
+import org.apache.maven.plugin.logging.Log;
+
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
-
-import imconfig.Configuration;
-import imconfig.ConfigurationException;
-import org.apache.maven.plugin.logging.Log;
-
-
-import iti.kukumo.core.Kukumo;
 
 
 public interface KukumoConfigurable {
 
     default Configuration readConfiguration(
-        List<String> confFiles,
-        Map<String, String> properties
+            List<String> confFiles,
+            Map<String, String> properties
     ) throws ConfigurationException {
         Configuration configuration = Kukumo.defaultConfiguration();
-        if (confFiles != null) {
+        if (!confFiles.isEmpty()) {
             for (String confFile : confFiles) {
-                configuration = configuration.appendFromPath(Path.of(confFile))
-                    .inner("kukumo");
+                configuration = Configuration.factory().merge(configuration,
+                        Configuration.factory().fromPath(Path.of(confFile)).inner("kukumo"));
             }
         }
-        if (properties != null) {
+        if (!properties.isEmpty()) {
             configuration = configuration.appendFromMap(properties);
         }
         if (configuration.isEmpty()) {

--- a/kukumo/kukumo-maven-plugin/src/test/java/iti/kukumo/maven/KukumoReportMojoTest.java
+++ b/kukumo/kukumo-maven-plugin/src/test/java/iti/kukumo/maven/KukumoReportMojoTest.java
@@ -1,0 +1,151 @@
+package iti.kukumo.maven;
+
+import imconfig.Configuration;
+import iti.kukumo.api.KukumoConfiguration;
+import iti.kukumo.api.plan.Result;
+import iti.kukumo.core.Kukumo;
+import iti.kukumo.maven.utils.KukumoAbstractMojoTest;
+import iti.kukumo.maven.utils.ProjectStub;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class KukumoReportMojoTest extends KukumoAbstractMojoTest {
+
+    private static final String GOAL = "report";
+    private Kukumo kukumo;
+    private Configuration currentConfiguration;
+
+    protected void setUp() throws Exception {
+        // required for mojo lookups to work
+        super.setUp();
+
+        kukumo = getKukumoMock();
+        doAnswer((a) -> currentConfiguration = a.getArgument(0, Configuration.class))
+                .when(kukumo).generateReports(any());
+    }
+
+    //Test
+    public void testWhenDefaultWithSuccess() throws Exception {
+        // Given
+        ProjectStub project = new ProjectStub(new File(getBasedir(), "src/test/resources/pom-default.xml"));
+        MavenSession session = newMavenSession(project);
+
+        // When
+        KukumoReporterMojo mojo = (KukumoReporterMojo) executeMojo(session, GOAL);
+
+        // Then
+        assertThat(currentConfiguration).isEqualTo(KukumoConfiguration.DEFAULTS);
+
+        assertThat(mojo.testFailureIgnore).isFalse();
+        assertThat(mojo.configurationFiles).isEmpty();
+        assertThat(mojo.properties).isEmpty();
+
+        assertThat(session.getResult().getExceptions()).isEmpty();
+        verify(kukumo, times(1)).generateReports(any());
+    }
+
+    //Test
+    public void testWhenPropertiesWithSuccess() throws Exception {
+        // Given
+        ProjectStub project = new ProjectStub(new File(getBasedir(), "src/test/resources/pom-properties.xml"));
+        Map<String, String> properties = getProjectProperties(project);
+        MavenSession session = newMavenSession(project);
+
+        // When
+        KukumoReporterMojo mojo = (KukumoReporterMojo) executeMojo(session, GOAL);
+
+        // Then
+        assertThat(currentConfiguration.asMap()).containsAllEntriesOf(properties);
+
+        assertThat(mojo.testFailureIgnore).isFalse();
+        assertThat(mojo.configurationFiles).isEmpty();
+        assertThat(mojo.properties).isEqualTo(properties);
+
+        assertThat(session.getResult().getExceptions()).isEmpty();
+        verify(kukumo, times(1)).generateReports(any());
+    }
+
+    //Test
+    public void testWhenConfigWithSuccess() throws Exception {
+        // Given
+        ProjectStub project = new ProjectStub(new File(getBasedir(), "src/test/resources/pom-config.xml"));
+        String configurationFiles = getProjectConfig(project, "configurationFiles");
+        Map<String, String> properties = Configuration.factory().fromPath(Path.of(configurationFiles)).inner("kukumo").asMap();
+        MavenSession session = newMavenSession(project);
+
+        // When
+        KukumoReporterMojo mojo = (KukumoReporterMojo) executeMojo(session, GOAL);
+
+        // Then
+        assertThat(currentConfiguration.asMap()).containsAllEntriesOf(properties);
+
+        assertThat(mojo.testFailureIgnore).isFalse();
+        assertThat(mojo.configurationFiles).isEqualTo(List.of(configurationFiles));
+        assertThat(mojo.properties).isEmpty();
+
+        assertThat(session.getResult().getExceptions()).isEmpty();
+        verify(kukumo, times(1)).generateReports(any());
+    }
+
+    //Test
+    public void testWhenIgnoreWithSuccess() throws Exception {
+        // Given
+        ProjectStub project = new ProjectStub(new File(getBasedir(), "src/test/resources/pom-ignore.xml"));
+        MavenSession session = newMavenSession(project);
+
+        // When
+        KukumoReporterMojo mojo = (KukumoReporterMojo) executeMojo(session, GOAL);
+
+        // Then
+        assertThat(mojo.testFailureIgnore).isTrue();
+
+        assertThat(session.getResult().getExceptions()).isEmpty();
+        verify(kukumo, times(1)).generateReports(any());
+    }
+
+    //Test
+    public void testWhenExceptionWithError() throws Exception {
+        // Given
+        doThrow(new RuntimeException("Error"))
+                .when(kukumo).generateReports(any());
+
+        ProjectStub project = new ProjectStub(new File(getBasedir(), "src/test/resources/pom-default.xml"));
+        MavenSession session = newMavenSession(project);
+
+        // When
+        executeMojo(session, GOAL);
+
+        // Then
+        assertThat(session.getResult().getExceptions()).hasSize(1);
+        assertThat(session.getResult().getExceptions().get(0)).isOfAnyClassIn(MojoExecutionException.class);
+        assertThat(session.getResult().getExceptions().get(0)).hasCauseInstanceOf(RuntimeException.class);
+        assertThat(session.getResult().getExceptions().get(0)).hasMessage("Kukumo configuration error: Error");
+        verify(kukumo, times(1)).generateReports(any());
+    }
+
+    //Test
+    public void testWhenExceptionAndIgnoreWithError() throws Exception {
+        // Given
+        doThrow(new RuntimeException("Error"))
+                .when(kukumo).generateReports(any());
+
+        ProjectStub project = new ProjectStub(new File(getBasedir(), "src/test/resources/pom-ignore.xml"));
+        MavenSession session = newMavenSession(project);
+
+        // When
+        executeMojo(session, GOAL);
+
+        // Then
+        assertThat(session.getResult().getExceptions()).isEmpty();
+        verify(kukumo, times(1)).generateReports(any());
+    }
+}

--- a/kukumo/kukumo-maven-plugin/src/test/java/iti/kukumo/maven/KukumoVerifyMojoTest.java
+++ b/kukumo/kukumo-maven-plugin/src/test/java/iti/kukumo/maven/KukumoVerifyMojoTest.java
@@ -1,0 +1,307 @@
+package iti.kukumo.maven;
+
+import imconfig.Configuration;
+import iti.kukumo.api.KukumoConfiguration;
+import iti.kukumo.api.KukumoException;
+import iti.kukumo.api.plan.PlanNode;
+import iti.kukumo.api.plan.Result;
+import iti.kukumo.core.Kukumo;
+import iti.kukumo.maven.utils.KukumoAbstractMojoTest;
+import iti.kukumo.maven.utils.ProjectStub;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class KukumoVerifyMojoTest extends KukumoAbstractMojoTest {
+
+    private static final String GOAL = "verify";
+
+    private PlanNode plan;
+    private Configuration currentConfiguration;
+
+    protected void setUp() throws Exception {
+        // required for mojo lookups to work
+        super.setUp();
+
+        plan = mock(PlanNode.class);
+        Kukumo kukumo = getKukumoMock();
+
+        when(kukumo.createPlanFromConfiguration(any(Configuration.class)))
+                .then((a) -> {
+                    currentConfiguration = a.getArgument(0, Configuration.class);
+                    return plan;
+                });
+        when(kukumo.executePlan(any(), any())).thenReturn(plan);
+    }
+
+
+    //Test
+    public void testWhenDefaultWithSuccess() throws Exception {
+        // Given
+        when(plan.result()).thenReturn(Optional.of(Result.PASSED));
+        when(plan.hasChildren()).thenReturn(true);
+
+        ProjectStub project = new ProjectStub(new File(getBasedir(), "src/test/resources/pom-default.xml"));
+        MavenSession session = newMavenSession(project);
+
+        // When
+        KukumoVerifyMojo mojo = (KukumoVerifyMojo) executeMojo(session, GOAL);
+
+        // Then
+        assertThat(currentConfiguration).isEqualTo(KukumoConfiguration.DEFAULTS);
+
+        assertThat(mojo.testFailureIgnore).isFalse();
+        assertThat(mojo.configurationFiles).isEmpty();
+        assertThat(mojo.logLevel).isEqualTo("info");
+        assertThat(mojo.skipTests).isFalse();
+        assertThat(mojo.properties).isEmpty();
+
+        assertThat(session.getResult().getExceptions()).isEmpty();
+        verify(plan, times(1)).result();
+    }
+
+    //Test
+    public void testWhenPropertiesWithSuccess() throws Exception {
+        // Given
+        when(plan.result()).thenReturn(Optional.of(Result.PASSED));
+        when(plan.hasChildren()).thenReturn(true);
+
+        ProjectStub project = new ProjectStub(new File(getBasedir(), "src/test/resources/pom-properties.xml"));
+        Map<String, String> properties = getProjectProperties(project);
+        MavenSession session = newMavenSession(project);
+
+        // When
+        KukumoVerifyMojo mojo = (KukumoVerifyMojo) executeMojo(session, GOAL);
+
+        // Then
+        assertThat(currentConfiguration.asMap()).containsAllEntriesOf(properties);
+
+        assertThat(mojo.testFailureIgnore).isFalse();
+        assertThat(mojo.configurationFiles).isEmpty();
+        assertThat(mojo.logLevel).isEqualTo("info");
+        assertThat(mojo.skipTests).isFalse();
+        assertThat(mojo.properties).isEqualTo(properties);
+
+        assertThat(session.getResult().getExceptions()).isEmpty();
+        verify(plan, times(1)).result();
+    }
+
+    //Test
+    public void testWhenConfigWithSuccess() throws Exception {
+        // Given
+        when(plan.result()).thenReturn(Optional.of(Result.PASSED));
+        when(plan.hasChildren()).thenReturn(true);
+
+        ProjectStub project = new ProjectStub(new File(getBasedir(), "src/test/resources/pom-config.xml"));
+        String configurationFiles = getProjectConfig(project, "configurationFiles");
+        Map<String, String> properties = Configuration.factory().fromPath(Path.of(configurationFiles)).inner("kukumo").asMap();
+        MavenSession session = newMavenSession(project);
+
+        // When
+        KukumoVerifyMojo mojo = (KukumoVerifyMojo) executeMojo(session, GOAL);
+
+        // Then
+        assertThat(currentConfiguration.asMap()).containsAllEntriesOf(properties);
+
+        assertThat(mojo.testFailureIgnore).isFalse();
+        assertThat(mojo.configurationFiles).isEqualTo(List.of(configurationFiles));
+        assertThat(mojo.logLevel).isEqualTo("info");
+        assertThat(mojo.skipTests).isFalse();
+        assertThat(mojo.properties).isEmpty();
+
+        assertThat(session.getResult().getExceptions()).isEmpty();
+        verify(plan, times(1)).result();
+    }
+
+    //Test
+    public void testWhenSkipTestWithSuccess() throws Exception {
+        // Given
+        ProjectStub project = new ProjectStub(new File(getBasedir(), "src/test/resources/pom-skip.xml"));
+        MavenSession session = newMavenSession(project);
+
+        // When
+        KukumoVerifyMojo mojo = (KukumoVerifyMojo) executeMojo(session, GOAL);
+
+        // Then
+        assertThat(mojo.skipTests).isTrue();
+
+        assertThat(session.getResult().getExceptions()).isEmpty();
+        verify(plan, times(0)).hasChildren();
+        verify(plan, times(0)).result();
+    }
+
+    //Test
+    public void testWhenLogLevelWithSuccess() throws Exception {
+        // Given
+        when(plan.result()).thenReturn(Optional.of(Result.PASSED));
+        when(plan.hasChildren()).thenReturn(true);
+
+        ProjectStub project = new ProjectStub(new File(getBasedir(), "src/test/resources/pom-log.xml"));
+        MavenSession session = newMavenSession(project);
+
+        // When
+        KukumoVerifyMojo mojo = (KukumoVerifyMojo) executeMojo(session, GOAL);
+
+        // Then
+        assertThat(mojo.logLevel).isEqualTo("debug");
+
+        assertThat(session.getResult().getExceptions()).isEmpty();
+        verify(plan, times(1)).result();
+    }
+
+    //Test
+    public void testWhenIgnoreWithSuccess() throws Exception {
+        // Given
+        when(plan.result()).thenReturn(Optional.of(Result.PASSED));
+        when(plan.hasChildren()).thenReturn(true);
+
+        ProjectStub project = new ProjectStub(new File(getBasedir(), "src/test/resources/pom-ignore.xml"));
+        MavenSession session = newMavenSession(project);
+
+        // When
+        KukumoVerifyMojo mojo = (KukumoVerifyMojo) executeMojo(session, GOAL);
+
+        // Then
+        assertThat(mojo.testFailureIgnore).isTrue();
+
+        assertThat(session.getResult().getExceptions()).isEmpty();
+        verify(plan, times(1)).result();
+    }
+
+    //Test
+    public void testWhenNotPassedWithError() throws Exception {
+        // Given
+        when(plan.result()).thenReturn(Optional.of(Result.FAILED));
+        when(plan.hasChildren()).thenReturn(true);
+
+        ProjectStub project = new ProjectStub(new File(getBasedir(), "src/test/resources/pom-default.xml"));
+        MavenSession session = newMavenSession(project);
+
+        // When
+        executeMojo(session, GOAL);
+
+        // Then
+        assertThat(session.getResult().getExceptions()).hasSize(1);
+        assertThat(session.getResult().getExceptions().get(0)).isOfAnyClassIn(MojoFailureException.class);
+        assertThat(session.getResult().getExceptions().get(0)).hasMessage("Kukumo Test Plan not passed");
+        verify(plan, times(1)).result();
+    }
+
+    //Test
+    public void testWhenKukumoExceptionWithError() throws Exception {
+        // Given
+        when(plan.result()).thenThrow(new KukumoException("Error"));
+        when(plan.hasChildren()).thenReturn(true);
+
+        ProjectStub project = new ProjectStub(new File(getBasedir(), "src/test/resources/pom-default.xml"));
+        MavenSession session = newMavenSession(project);
+
+        // When
+        executeMojo(session, GOAL);
+
+        // Then
+        assertThat(session.getResult().getExceptions()).hasSize(1);
+        assertThat(session.getResult().getExceptions().get(0)).isOfAnyClassIn(MojoFailureException.class);
+        assertThat(session.getResult().getExceptions().get(0)).hasCauseInstanceOf(KukumoException.class);
+        assertThat(session.getResult().getExceptions().get(0)).hasMessage("Kukumo error: Error");
+        verify(plan, times(1)).result();
+    }
+
+    //Test
+    public void testWhenExceptionWithError() throws Exception {
+        // Given
+        when(plan.result()).thenThrow(new RuntimeException("Error"));
+        when(plan.hasChildren()).thenReturn(true);
+
+        ProjectStub project = new ProjectStub(new File(getBasedir(), "src/test/resources/pom-default.xml"));
+        MavenSession session = newMavenSession(project);
+
+        // When
+        executeMojo(session, GOAL);
+
+        // Then
+        assertThat(session.getResult().getExceptions()).hasSize(1);
+        assertThat(session.getResult().getExceptions().get(0)).isOfAnyClassIn(MojoExecutionException.class);
+        assertThat(session.getResult().getExceptions().get(0)).hasCauseInstanceOf(RuntimeException.class);
+        assertThat(session.getResult().getExceptions().get(0)).hasMessage("Kukumo configuration error: Error");
+        verify(plan, times(1)).result();
+    }
+
+    //Test
+    public void testWhenNotPassedAndIgnoreWithSuccess() throws Exception {
+        // Given
+        when(plan.result()).thenReturn(Optional.of(Result.FAILED));
+        when(plan.hasChildren()).thenReturn(true);
+
+        ProjectStub project = new ProjectStub(new File(getBasedir(), "src/test/resources/pom-ignore.xml"));
+        MavenSession session = newMavenSession(project);
+
+        // When
+        executeMojo(session, GOAL);
+
+        // Then
+        assertThat(session.getResult().getExceptions()).isEmpty();
+        verify(plan, times(1)).result();
+    }
+
+    //Test
+    public void testWhenKukumoExceptionAndIgnoreWithError() throws Exception {
+        // Given
+        when(plan.result()).thenThrow(new KukumoException("Error"));
+        when(plan.hasChildren()).thenReturn(true);
+
+        ProjectStub project = new ProjectStub(new File(getBasedir(), "src/test/resources/pom-ignore.xml"));
+        MavenSession session = newMavenSession(project);
+
+        // When
+        executeMojo(session, GOAL);
+
+        // Then
+        assertThat(session.getResult().getExceptions()).isEmpty();
+        verify(plan, times(1)).result();
+    }
+
+    //Test
+    public void testWhenExceptionAndIgnoreWithError() throws Exception {
+        // Given
+        when(plan.result()).thenThrow(new RuntimeException("Error"));
+        when(plan.hasChildren()).thenReturn(true);
+
+        ProjectStub project = new ProjectStub(new File(getBasedir(), "src/test/resources/pom-ignore.xml"));
+        MavenSession session = newMavenSession(project);
+
+        // When
+        executeMojo(session, GOAL);
+
+        // Then
+        assertThat(session.getResult().getExceptions()).isEmpty();
+        verify(plan, times(1)).result();
+    }
+
+    //Test
+    public void testWhenNoChildrenWithSuccess() throws Exception {
+        // Given
+        when(plan.hasChildren()).thenReturn(false);
+
+        ProjectStub project = new ProjectStub(new File(getBasedir(), "src/test/resources/pom-default.xml"));
+        MavenSession session = newMavenSession(project);
+
+        // When
+        executeMojo(session, GOAL);
+
+        // Then
+        assertThat(session.getResult().getExceptions()).isEmpty();
+        verify(plan, times(0)).result();
+    }
+
+}

--- a/kukumo/kukumo-maven-plugin/src/test/java/iti/kukumo/maven/utils/KukumoAbstractMojoTest.java
+++ b/kukumo/kukumo-maven-plugin/src/test/java/iti/kukumo/maven/utils/KukumoAbstractMojoTest.java
@@ -1,0 +1,59 @@
+package iti.kukumo.maven.utils;
+
+import iti.kukumo.core.Kukumo;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.plugin.Mojo;
+import org.apache.maven.plugin.testing.AbstractMojoTestCase;
+import org.apache.maven.project.MavenProject;
+import org.codehaus.plexus.util.xml.Xpp3Dom;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+public abstract class KukumoAbstractMojoTest extends AbstractMojoTestCase {
+
+    private Kukumo kukumo;
+
+    protected Kukumo getKukumoMock() {
+        return kukumo;
+    }
+
+    protected void setUp() throws Exception {
+        // required for mojo lookups to work
+        super.setUp();
+
+        kukumo = mock(Kukumo.class);
+
+        Field instance = Kukumo.class.getDeclaredField("instance");
+        instance.setAccessible(true);
+        instance.set(null, kukumo);
+        Field instantiated = Kukumo.class.getDeclaredField("instantiated");
+        instantiated.setAccessible(true);
+        ((AtomicBoolean) instantiated.get(null)).set(true);
+    }
+
+    protected Mojo executeMojo(MavenSession session, String goal) throws Exception {
+        Mojo mojo = lookupConfiguredMojo(session, newMojoExecution(goal));
+        assertThat(mojo).isNotNull();
+        mojo.execute();
+        return mojo;
+    }
+
+    protected Map<String, String> getProjectProperties(MavenProject project) {
+        Plugin plugin = project.getBuildPlugins().get(0);
+        return Arrays.stream(((Xpp3Dom) plugin.getConfiguration()).getChild("properties").getChildren())
+                .collect(Collectors.toMap(Xpp3Dom::getName, Xpp3Dom::getValue));
+    }
+
+    protected String getProjectConfig(MavenProject project, String property) {
+        Plugin plugin = project.getBuildPlugins().get(0);
+        return ((Xpp3Dom) plugin.getConfiguration()).getChild(property).getValue();
+    }
+}

--- a/kukumo/kukumo-maven-plugin/src/test/java/iti/kukumo/maven/utils/ProjectStub.java
+++ b/kukumo/kukumo-maven-plugin/src/test/java/iti/kukumo/maven/utils/ProjectStub.java
@@ -1,0 +1,50 @@
+package iti.kukumo.maven.utils;
+
+import org.apache.maven.model.Model;
+import org.apache.maven.model.Plugin;
+import org.apache.maven.model.io.xpp3.MavenXpp3Reader;
+import org.apache.maven.plugin.testing.stubs.MavenProjectStub;
+import org.apache.maven.shared.utils.ReaderFactory;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ProjectStub extends MavenProjectStub {
+
+    public ProjectStub(File pom) {
+        final MavenXpp3Reader pomReader = new MavenXpp3Reader();
+        Model model;
+        try {
+            model = pomReader.read(ReaderFactory.newXmlReader(pom));
+            setModel(model);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        setGroupId(model.getGroupId());
+        setArtifactId(model.getArtifactId());
+        setVersion(model.getVersion());
+        setName(model.getName());
+        setUrl(model.getUrl());
+        setPackaging(model.getPackaging());
+        setBuild(model.getBuild());
+
+        final List<String> compileSourceRoots = new ArrayList<>();
+        compileSourceRoots.add(getBasedir() + "/src/main/java");
+        setCompileSourceRoots(compileSourceRoots);
+
+        final List<String> testCompileSourceRoots = new ArrayList<>();
+        testCompileSourceRoots.add(getBasedir() + "/src/test/java");
+        setTestCompileSourceRoots(testCompileSourceRoots);
+
+        // normalize some expressions
+        getBuild().setDirectory("${project.basedir}/target");
+        getBuild().setTestOutputDirectory(new File(getBasedir(), "target/classes").getAbsolutePath());
+    }
+
+    @Override
+    public List<Plugin> getBuildPlugins() {
+        return getBuild().getPlugins();
+    }
+}

--- a/kukumo/kukumo-maven-plugin/src/test/resources/kukumo.yaml
+++ b/kukumo/kukumo-maven-plugin/src/test/resources/kukumo.yaml
@@ -1,0 +1,32 @@
+kukumo:
+  resourceTypes: other
+  language: es
+  resourcePath: src/test/resources
+  outputFilePath: target/kukumo/kukumo.json
+  report:
+    generation: "false"
+  idTagPattern: ID_\d+
+  redefinition:
+    enabled: "true"
+    definitionTag: def
+    implementationTag: impl
+  junit:
+    treatStepsAsTests: "true"
+  logs:
+    showLogo: "false"
+    showStepSource: "true"
+    showElapsedTime: "false"
+    ansi:
+      styles:
+        keyword: "true"
+        source: other
+        time: other
+        contributor: pink
+        stepResult:
+          PASSED: pink,bold
+          SKIPPED: other
+          UNDEFINED: pink
+          FAILED: pink,bold
+          ERROR: pink,bold
+  htmlReport:
+    output: target/kukumo/kukumo.html

--- a/kukumo/kukumo-maven-plugin/src/test/resources/pom-config.xml
+++ b/kukumo/kukumo-maven-plugin/src/test/resources/pom-config.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ This Source Code Form is subject to the terms of the Mozilla Public
+  ~ License, v. 2.0. If a copy of the MPL was not distributed with this
+  ~ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+  -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>es.iti.kukumo</groupId>
+    <artifactId>spring-verify-example</artifactId>
+    <version>0.0.1</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>es.iti.kukumo</groupId>
+                <artifactId>kukumo-maven-plugin</artifactId>
+                <version>0.0.1</version>
+                <configuration>
+                    <configurationFiles>src/test/resources/kukumo.yaml</configurationFiles>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/kukumo/kukumo-maven-plugin/src/test/resources/pom-default.xml
+++ b/kukumo/kukumo-maven-plugin/src/test/resources/pom-default.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ This Source Code Form is subject to the terms of the Mozilla Public
+  ~ License, v. 2.0. If a copy of the MPL was not distributed with this
+  ~ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+  -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>es.iti.kukumo</groupId>
+    <artifactId>spring-verify-example</artifactId>
+    <version>0.0.1</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>es.iti.kukumo</groupId>
+                <artifactId>kukumo-maven-plugin</artifactId>
+                <version>0.0.1</version>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/kukumo/kukumo-maven-plugin/src/test/resources/pom-ignore.xml
+++ b/kukumo/kukumo-maven-plugin/src/test/resources/pom-ignore.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ This Source Code Form is subject to the terms of the Mozilla Public
+  ~ License, v. 2.0. If a copy of the MPL was not distributed with this
+  ~ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+  -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>es.iti.kukumo</groupId>
+    <artifactId>spring-verify-example</artifactId>
+    <version>0.0.1</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>es.iti.kukumo</groupId>
+                <artifactId>kukumo-maven-plugin</artifactId>
+                <version>0.0.1</version>
+                <configuration>
+                    <testFailureIgnore>true</testFailureIgnore>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/kukumo/kukumo-maven-plugin/src/test/resources/pom-log.xml
+++ b/kukumo/kukumo-maven-plugin/src/test/resources/pom-log.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ This Source Code Form is subject to the terms of the Mozilla Public
+  ~ License, v. 2.0. If a copy of the MPL was not distributed with this
+  ~ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+  -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>es.iti.kukumo</groupId>
+    <artifactId>spring-verify-example</artifactId>
+    <version>0.0.1</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>es.iti.kukumo</groupId>
+                <artifactId>kukumo-maven-plugin</artifactId>
+                <version>0.0.1</version>
+                <configuration>
+                    <logLevel>debug</logLevel>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/kukumo/kukumo-maven-plugin/src/test/resources/pom-properties.xml
+++ b/kukumo/kukumo-maven-plugin/src/test/resources/pom-properties.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ This Source Code Form is subject to the terms of the Mozilla Public
+  ~ License, v. 2.0. If a copy of the MPL was not distributed with this
+  ~ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+  -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>es.iti.kukumo</groupId>
+    <artifactId>spring-verify-example</artifactId>
+    <version>0.0.1</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>es.iti.kukumo</groupId>
+                <artifactId>kukumo-maven-plugin</artifactId>
+                <version>0.0.1</version>
+                <configuration>
+                    <!-- Kukumo configuration -->
+                    <properties>
+                        <resourceTypes>other</resourceTypes>
+                        <language>es</language>
+                        <resourcePath>src/test/resources</resourcePath>
+                        <outputFilePath>target/kukumo/kukumo.json</outputFilePath>
+                        <report.generation>false</report.generation>
+                        <idTagPattern>ID_\d+</idTagPattern>
+                        <redefinition.enabled>true</redefinition.enabled>
+                        <redefinition.definitionTag>def</redefinition.definitionTag>
+                        <redefinition.implementationTag>impl</redefinition.implementationTag>
+                        <logs.showLogo>false</logs.showLogo>
+                        <logs.showStepSource>true</logs.showStepSource>
+                        <logs.showElapsedTime>false</logs.showElapsedTime>
+                        <junit.treatStepsAsTests>true</junit.treatStepsAsTests>
+                        <logs.ansi.styles.keyword>pink</logs.ansi.styles.keyword>
+                        <logs.ansi.styles.source>other</logs.ansi.styles.source>
+                        <logs.ansi.styles.time>other</logs.ansi.styles.time>
+                        <logs.ansi.styles.resourceType>pink</logs.ansi.styles.resourceType>
+                        <logs.ansi.styles.contributor>pink</logs.ansi.styles.contributor>
+                        <logs.ansi.styles.stepResult.PASSED>pink,bold</logs.ansi.styles.stepResult.PASSED>
+                        <logs.ansi.styles.stepResult.SKIPPED>other</logs.ansi.styles.stepResult.SKIPPED>
+                        <logs.ansi.styles.stepResult.UNDEFINED>pink</logs.ansi.styles.stepResult.UNDEFINED>
+                        <logs.ansi.styles.stepResult.FAILED>pink,bold</logs.ansi.styles.stepResult.FAILED>
+                        <logs.ansi.styles.stepResult.ERROR>pink,bold</logs.ansi.styles.stepResult.ERROR>
+                        <htmlReport.output>target/kukumo/kukumo.html</htmlReport.output>
+                    </properties>
+
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/kukumo/kukumo-maven-plugin/src/test/resources/pom-skip.xml
+++ b/kukumo/kukumo-maven-plugin/src/test/resources/pom-skip.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ This Source Code Form is subject to the terms of the Mozilla Public
+  ~ License, v. 2.0. If a copy of the MPL was not distributed with this
+  ~ file, You can obtain one at https://mozilla.org/MPL/2.0/.
+  -->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>es.iti.kukumo</groupId>
+    <artifactId>spring-verify-example</artifactId>
+    <version>0.0.1</version>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>es.iti.kukumo</groupId>
+                <artifactId>kukumo-maven-plugin</artifactId>
+                <version>0.0.1</version>
+                <configuration>
+                    <skipTests>true</skipTests>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
Corrección del issue #54 

Los cambios incluyen:
- Evitar que se detenga el pipeline cuando kukumo falla (bien porque tests no pasan o porque ha habido algún otro problema), y esperar al final del pipeline para indicar el error.
- Corregir la carga de propiedades desde fichero externo.
- Añadir otras configuraciones interesantes para depurar (testFailureIgnore)
- Añadir tests unitarios